### PR TITLE
Refactor repo into frontend and backend modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ A visual AI playground. Tersa is an open source canvas for building AI workflows
 
 - [Next.js 15](https://nextjs.org/) with App Router and Turbopack
 - [React 19](https://react.dev/)
+## Repository Structure
+
+- `frontend/` - Vite + React app
+- `backend/` - NestJS API server
+
 - [Clerk](https://clerk.com/) for authentication
 - [Prisma](https://www.prisma.io/) for database queries
 - [Vercel AI SDK](https://sdk.vercel.ai/) for AI model integration

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,12 @@
+# Tersa Backend
+
+NestJS backend for the Tersa application. Provides API routes under `/api`.
+
+## Development
+
+```bash
+pnpm install
+pnpm run dev
+```
+
+The API will run on `http://localhost:3001/api` and allows CORS requests from `http://localhost:5173`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "tersa-backend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "nest start --watch",
+    "build": "nest build"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.3.0",
+    "@nestjs/config": "^3.2.0",
+    "@nestjs/core": "^10.3.0",
+    "@nestjs/platform-express": "^10.3.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1",
+    "@prisma/client": "^5.14.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.3.0",
+    "@nestjs/schematics": "^10.3.0",
+    "@nestjs/testing": "^10.3.0",
+    "prisma": "^5.14.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
+  }
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,34 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Project {
+  id                 String   @id @default(uuid())
+  name               String
+  transcriptionModel String   @map("transcription_model")
+  visionModel        String   @map("vision_model")
+  createdAt          DateTime @default(now()) @map("created_at")
+  updatedAt          DateTime? @map("updated_at")
+  content            Json?
+  userId             String   @map("user_id")
+  image              String?
+  members            String[]
+  welcomeProject     Boolean  @default(false) @map("demo_project")
+
+  @@map("project")
+}
+
+model Profile {
+  id             String   @id
+  customerId     String?  @map("customer_id")
+  subscriptionId String?  @map("subscription_id")
+  productId      String?  @map("product_id")
+  onboardedAt    DateTime? @map("onboarded_at")
+
+  @@map("profile")
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { ProjectsModule } from './projects/projects.module';
+import { AuthModule } from './auth/auth.module';
+
+@Module({
+  imports: [ConfigModule.forRoot({ isGlobal: true }), ProjectsModule, AuthModule],
+})
+export class AppModule {}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('auth')
+export class AuthController {
+  @Get('status')
+  status() {
+    return { status: 'ok' };
+  }
+}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+
+@Module({
+  controllers: [AuthController],
+})
+export class AuthModule {}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,15 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { ConfigService } from '@nestjs/config';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const config = app.get(ConfigService);
+  app.setGlobalPrefix('api');
+  app.enableCors({ origin: 'http://localhost:5173' });
+  const port = config.get('PORT') || 3001;
+  await app.listen(port);
+  console.log(`Backend running on http://localhost:${port}`);
+}
+
+bootstrap();

--- a/backend/src/projects/projects.controller.ts
+++ b/backend/src/projects/projects.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { ProjectsService } from './projects.service';
+
+@Controller('projects')
+export class ProjectsController {
+  constructor(private readonly projectsService: ProjectsService) {}
+
+  @Get()
+  findAll() {
+    return this.projectsService.findAll();
+  }
+}

--- a/backend/src/projects/projects.module.ts
+++ b/backend/src/projects/projects.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ProjectsService } from './projects.service';
+import { ProjectsController } from './projects.controller';
+
+@Module({
+  controllers: [ProjectsController],
+  providers: [ProjectsService],
+})
+export class ProjectsModule {}

--- a/backend/src/projects/projects.service.ts
+++ b/backend/src/projects/projects.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ProjectsService {
+  private projects = [{ id: '1', name: 'Example Project' }];
+
+  findAll() {
+    return this.projects;
+  }
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2017",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true
+  },
+  "exclude": ["node_modules", "dist"],
+  "include": ["src/**/*"]
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,12 @@
+# Tersa Frontend
+
+This package contains the Vite + React implementation of the Tersa UI.
+
+## Development
+
+```bash
+pnpm install
+pnpm dev
+```
+
+The app will be available at http://localhost:5173 and expects the backend to run at the URL defined in `.env`.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tersa</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "tersa-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext .ts,.tsx"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "^2.2.3",
+    "axios": "^1.6.7",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-redux": "^9.1.2",
+    "react-router-dom": "^6.23.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.25",
+    "@types/react-dom": "^19.0.11",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,10 @@
+import { Route, Routes } from 'react-router-dom';
+import HomePage from './pages/HomePage';
+
+const App = () => (
+  <Routes>
+    <Route path="/" element={<HomePage />} />
+  </Routes>
+);
+
+export default App;

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3001/api',
+});
+
+export default api;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import { store } from './store';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Provider store={store}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>
+  </React.StrictMode>,
+);

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,5 @@
+const HomePage = () => {
+  return <div>Welcome to Tersa</div>;
+};
+
+export default HomePage;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,0 +1,22 @@
+import { configureStore, createSlice } from '@reduxjs/toolkit';
+
+const counterSlice = createSlice({
+  name: 'counter',
+  initialState: { value: 0 },
+  reducers: {
+    increment: (state) => {
+      state.value += 1;
+    },
+  },
+});
+
+export const { increment } = counterSlice.actions;
+
+export const store = configureStore({
+  reducer: {
+    counter: counterSlice.reducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- set up `frontend/` Vite + React project with Redux store and basic routing
- set up `backend/` NestJS API with global `/api` prefix and CORS
- copy Prisma schema to backend
- update root README to describe new repository structure

## Testing
- `pnpm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6874e44810e8832b9119957a2e8b341d